### PR TITLE
Compilation error with with BUILD_SHARED_LIBS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ if (APPLE)
 	set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -xobjective-c++)
 endif()
 
+if (BUILD_SHARED_LIBS)
+	set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+
 add_subdirectory(Renderer)
 add_subdirectory(TweakBar)
 


### PR DESCRIPTION
I tried to compile with GCC 7.5.0 with the shared library target on, but the build failed because building the shared object required the object files to be compiled with the position independent code flag.
I searched in google on how to enable this flag in CMake, and found this workaround.
I don't know if it's a good solution or not, because it also compiles the examples with this flag on, so please refactor that change if needed.